### PR TITLE
remove null from optional field type union

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -391,7 +391,7 @@ function buildType(ref, type) {
             push("");
             var jsType = toJsType(field);
             if (field.optional && !field.map && !field.repeated && field.resolvedType instanceof Type)
-                jsType = "(" + jsType + "|null|undefined)";
+                jsType = "(" + jsType + "|undefined)";
             pushComment([
                 field.comment || type.name + " " + field.name + ".",
                 "@member {" + jsType + "}" + escapeName(field.name),

--- a/tests/data/package.d.ts
+++ b/tests/data/package.d.ts
@@ -28,7 +28,7 @@ export class Package {
     public description: string;
     public author: string;
     public license: string;
-    public repository?: (Package.IRepository|null);
+    public repository?: Package.IRepository;
     public bugs: string;
     public homepage: string;
     public keywords: string[];

--- a/tests/data/package.js
+++ b/tests/data/package.js
@@ -104,7 +104,7 @@ $root.Package = (function() {
 
     /**
      * Package repository.
-     * @member {(Package.IRepository|null|undefined)}repository
+     * @member {(Package.IRepository|undefined)}repository
      * @memberof Package
      * @instance
      */

--- a/tests/data/test.d.ts
+++ b/tests/data/test.d.ts
@@ -121,7 +121,7 @@ export namespace jspb {
             constructor(properties?: jspb.test.IOptionalFields);
             public aString: string;
             public aBool: boolean;
-            public aNestedMessage?: (jspb.test.OptionalFields.INested|null);
+            public aNestedMessage?: jspb.test.OptionalFields.INested;
             public aRepeatedMessage: jspb.test.OptionalFields.INested[];
             public aRepeatedString: string[];
             public static create(properties?: jspb.test.IOptionalFields): jspb.test.OptionalFields;
@@ -196,7 +196,7 @@ export namespace jspb {
             constructor(properties?: jspb.test.IComplex);
             public aString: string;
             public anOutOfOrderBool: boolean;
-            public aNestedMessage?: (jspb.test.Complex.INested|null);
+            public aNestedMessage?: jspb.test.Complex.INested;
             public aRepeatedMessage: jspb.test.Complex.INested[];
             public aRepeatedString: string[];
             public static create(properties?: jspb.test.IComplex): jspb.test.Complex;
@@ -382,7 +382,7 @@ export namespace jspb {
         class TestClone {
             constructor(properties?: jspb.test.ITestClone);
             public str: string;
-            public simple1?: (jspb.test.ISimple1|null);
+            public simple1?: jspb.test.ISimple1;
             public simple2: jspb.test.ISimple1[];
             public bytesField: Uint8Array;
             public unused: string;
@@ -428,10 +428,10 @@ export namespace jspb {
             constructor(properties?: jspb.test.ITestGroup);
             public repeatedGroup: jspb.test.TestGroup.IRepeatedGroup[];
             public requiredGroup: jspb.test.TestGroup.IRequiredGroup;
-            public optionalGroup?: (jspb.test.TestGroup.IOptionalGroup|null);
+            public optionalGroup?: jspb.test.TestGroup.IOptionalGroup;
             public id: string;
             public requiredSimple: jspb.test.ISimple2;
-            public optionalSimple?: (jspb.test.ISimple2|null);
+            public optionalSimple?: jspb.test.ISimple2;
             public static create(properties?: jspb.test.ITestGroup): jspb.test.TestGroup;
             public static encode(message: jspb.test.ITestGroup, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.ITestGroup, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -508,7 +508,7 @@ export namespace jspb {
 
         class TestGroup1 {
             constructor(properties?: jspb.test.ITestGroup1);
-            public group?: (jspb.test.TestGroup.IRepeatedGroup|null);
+            public group?: jspb.test.TestGroup.IRepeatedGroup;
             public static create(properties?: jspb.test.ITestGroup1): jspb.test.TestGroup1;
             public static encode(message: jspb.test.ITestGroup1, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: jspb.test.ITestGroup1, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -572,7 +572,7 @@ export namespace jspb {
             constructor(properties?: jspb.test.ITestMessageWithOneof);
             public pone: string;
             public pthree: string;
-            public rone?: (jspb.test.ITestMessageWithOneof|null);
+            public rone?: jspb.test.ITestMessageWithOneof;
             public rtwo: string;
             public normalField: boolean;
             public repeatedField: string[];
@@ -642,7 +642,7 @@ export namespace jspb {
             public mapInt32String: { [k: string]: string };
             public mapInt64String: { [k: string]: string };
             public mapBoolString: { [k: string]: string };
-            public testMapFields?: (jspb.test.ITestMapFieldsNoBinary|null);
+            public testMapFields?: jspb.test.ITestMapFieldsNoBinary;
             public mapStringTestmapfields: { [k: string]: jspb.test.ITestMapFieldsNoBinary };
             public static create(properties?: jspb.test.ITestMapFieldsNoBinary): jspb.test.TestMapFieldsNoBinary;
             public static encode(message: jspb.test.ITestMapFieldsNoBinary, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -785,8 +785,8 @@ export namespace google {
             public enumType: google.protobuf.IEnumDescriptorProto[];
             public service: google.protobuf.IServiceDescriptorProto[];
             public extension: google.protobuf.IFieldDescriptorProto[];
-            public options?: (google.protobuf.IFileOptions|null);
-            public sourceCodeInfo?: (google.protobuf.ISourceCodeInfo|null);
+            public options?: google.protobuf.IFileOptions;
+            public sourceCodeInfo?: google.protobuf.ISourceCodeInfo;
             public syntax: string;
             public static create(properties?: google.protobuf.IFileDescriptorProto): google.protobuf.FileDescriptorProto;
             public static encode(message: google.protobuf.IFileDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -821,7 +821,7 @@ export namespace google {
             public enumType: google.protobuf.IEnumDescriptorProto[];
             public extensionRange: google.protobuf.DescriptorProto.IExtensionRange[];
             public oneofDecl: google.protobuf.IOneofDescriptorProto[];
-            public options?: (google.protobuf.IMessageOptions|null);
+            public options?: google.protobuf.IMessageOptions;
             public reservedRange: google.protobuf.DescriptorProto.IReservedRange[];
             public reservedName: string[];
             public static create(properties?: google.protobuf.IDescriptorProto): google.protobuf.DescriptorProto;
@@ -902,7 +902,7 @@ export namespace google {
             public defaultValue: string;
             public oneofIndex: number;
             public jsonName: string;
-            public options?: (google.protobuf.IFieldOptions|null);
+            public options?: google.protobuf.IFieldOptions;
             public static create(properties?: google.protobuf.IFieldDescriptorProto): google.protobuf.FieldDescriptorProto;
             public static encode(message: google.protobuf.IFieldDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: google.protobuf.IFieldDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -952,7 +952,7 @@ export namespace google {
         class OneofDescriptorProto {
             constructor(properties?: google.protobuf.IOneofDescriptorProto);
             public name: string;
-            public options?: (google.protobuf.IOneofOptions|null);
+            public options?: google.protobuf.IOneofOptions;
             public static create(properties?: google.protobuf.IOneofDescriptorProto): google.protobuf.OneofDescriptorProto;
             public static encode(message: google.protobuf.IOneofDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: google.protobuf.IOneofDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -974,7 +974,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IEnumDescriptorProto);
             public name: string;
             public value: google.protobuf.IEnumValueDescriptorProto[];
-            public options?: (google.protobuf.IEnumOptions|null);
+            public options?: google.protobuf.IEnumOptions;
             public static create(properties?: google.protobuf.IEnumDescriptorProto): google.protobuf.EnumDescriptorProto;
             public static encode(message: google.protobuf.IEnumDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: google.protobuf.IEnumDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -996,7 +996,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IEnumValueDescriptorProto);
             public name: string;
             public number: number;
-            public options?: (google.protobuf.IEnumValueOptions|null);
+            public options?: google.protobuf.IEnumValueOptions;
             public static create(properties?: google.protobuf.IEnumValueDescriptorProto): google.protobuf.EnumValueDescriptorProto;
             public static encode(message: google.protobuf.IEnumValueDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: google.protobuf.IEnumValueDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -1018,7 +1018,7 @@ export namespace google {
             constructor(properties?: google.protobuf.IServiceDescriptorProto);
             public name: string;
             public method: google.protobuf.IMethodDescriptorProto[];
-            public options?: (google.protobuf.IServiceOptions|null);
+            public options?: google.protobuf.IServiceOptions;
             public static create(properties?: google.protobuf.IServiceDescriptorProto): google.protobuf.ServiceDescriptorProto;
             public static encode(message: google.protobuf.IServiceDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
             public static encodeDelimited(message: google.protobuf.IServiceDescriptorProto, writer?: $protobuf.Writer): $protobuf.Writer;
@@ -1044,7 +1044,7 @@ export namespace google {
             public name: string;
             public inputType: string;
             public outputType: string;
-            public options?: (google.protobuf.IMethodOptions|null);
+            public options?: google.protobuf.IMethodOptions;
             public clientStreaming: boolean;
             public serverStreaming: boolean;
             public static create(properties?: google.protobuf.IMethodDescriptorProto): google.protobuf.MethodDescriptorProto;

--- a/tests/data/test.js
+++ b/tests/data/test.js
@@ -1171,7 +1171,7 @@ $root.jspb = (function() {
 
             /**
              * OptionalFields aNestedMessage.
-             * @member {(jspb.test.OptionalFields.INested|null|undefined)}aNestedMessage
+             * @member {(jspb.test.OptionalFields.INested|undefined)}aNestedMessage
              * @memberof jspb.test.OptionalFields
              * @instance
              */
@@ -1688,7 +1688,7 @@ $root.jspb = (function() {
 
             /**
              * HasExtensions .jspb.test.IsExtension.extField.
-             * @member {(jspb.test.IIsExtension|null|undefined)}.jspb.test.IsExtension.extField
+             * @member {(jspb.test.IIsExtension|undefined)}.jspb.test.IsExtension.extField
              * @memberof jspb.test.HasExtensions
              * @instance
              */
@@ -1696,7 +1696,7 @@ $root.jspb = (function() {
 
             /**
              * HasExtensions .jspb.test.IndirectExtension.simple.
-             * @member {(jspb.test.ISimple1|null|undefined)}.jspb.test.IndirectExtension.simple
+             * @member {(jspb.test.ISimple1|undefined)}.jspb.test.IndirectExtension.simple
              * @memberof jspb.test.HasExtensions
              * @instance
              */
@@ -1728,7 +1728,7 @@ $root.jspb = (function() {
 
             /**
              * HasExtensions .jspb.test.simple1.
-             * @member {(jspb.test.ISimple1|null|undefined)}.jspb.test.simple1
+             * @member {(jspb.test.ISimple1|undefined)}.jspb.test.simple1
              * @memberof jspb.test.HasExtensions
              * @instance
              */
@@ -2093,7 +2093,7 @@ $root.jspb = (function() {
 
             /**
              * Complex aNestedMessage.
-             * @member {(jspb.test.Complex.INested|null|undefined)}aNestedMessage
+             * @member {(jspb.test.Complex.INested|undefined)}aNestedMessage
              * @memberof jspb.test.Complex
              * @instance
              */
@@ -4009,7 +4009,7 @@ $root.jspb = (function() {
 
             /**
              * TestClone simple1.
-             * @member {(jspb.test.ISimple1|null|undefined)}simple1
+             * @member {(jspb.test.ISimple1|undefined)}simple1
              * @memberof jspb.test.TestClone
              * @instance
              */
@@ -4041,7 +4041,7 @@ $root.jspb = (function() {
 
             /**
              * TestClone .jspb.test.CloneExtension.extField.
-             * @member {(jspb.test.ICloneExtension|null|undefined)}.jspb.test.CloneExtension.extField
+             * @member {(jspb.test.ICloneExtension|undefined)}.jspb.test.CloneExtension.extField
              * @memberof jspb.test.TestClone
              * @instance
              */
@@ -4535,7 +4535,7 @@ $root.jspb = (function() {
 
             /**
              * TestGroup optionalGroup.
-             * @member {(jspb.test.TestGroup.IOptionalGroup|null|undefined)}optionalGroup
+             * @member {(jspb.test.TestGroup.IOptionalGroup|undefined)}optionalGroup
              * @memberof jspb.test.TestGroup
              * @instance
              */
@@ -4559,7 +4559,7 @@ $root.jspb = (function() {
 
             /**
              * TestGroup optionalSimple.
-             * @member {(jspb.test.ISimple2|null|undefined)}optionalSimple
+             * @member {(jspb.test.ISimple2|undefined)}optionalSimple
              * @memberof jspb.test.TestGroup
              * @instance
              */
@@ -5458,7 +5458,7 @@ $root.jspb = (function() {
 
             /**
              * TestGroup1 group.
-             * @member {(jspb.test.TestGroup.IRepeatedGroup|null|undefined)}group
+             * @member {(jspb.test.TestGroup.IRepeatedGroup|undefined)}group
              * @memberof jspb.test.TestGroup1
              * @instance
              */
@@ -6043,7 +6043,7 @@ $root.jspb = (function() {
 
             /**
              * TestMessageWithOneof rone.
-             * @member {(jspb.test.ITestMessageWithOneof|null|undefined)}rone
+             * @member {(jspb.test.ITestMessageWithOneof|undefined)}rone
              * @memberof jspb.test.TestMessageWithOneof
              * @instance
              */
@@ -6824,7 +6824,7 @@ $root.jspb = (function() {
 
             /**
              * TestMapFieldsNoBinary testMapFields.
-             * @member {(jspb.test.ITestMapFieldsNoBinary|null|undefined)}testMapFields
+             * @member {(jspb.test.ITestMapFieldsNoBinary|undefined)}testMapFields
              * @memberof jspb.test.TestMapFieldsNoBinary
              * @instance
              */
@@ -8456,7 +8456,7 @@ $root.google = (function() {
 
             /**
              * FileDescriptorProto options.
-             * @member {(google.protobuf.IFileOptions|null|undefined)}options
+             * @member {(google.protobuf.IFileOptions|undefined)}options
              * @memberof google.protobuf.FileDescriptorProto
              * @instance
              */
@@ -8464,7 +8464,7 @@ $root.google = (function() {
 
             /**
              * FileDescriptorProto sourceCodeInfo.
-             * @member {(google.protobuf.ISourceCodeInfo|null|undefined)}sourceCodeInfo
+             * @member {(google.protobuf.ISourceCodeInfo|undefined)}sourceCodeInfo
              * @memberof google.protobuf.FileDescriptorProto
              * @instance
              */
@@ -9022,7 +9022,7 @@ $root.google = (function() {
 
             /**
              * DescriptorProto options.
-             * @member {(google.protobuf.IMessageOptions|null|undefined)}options
+             * @member {(google.protobuf.IMessageOptions|undefined)}options
              * @memberof google.protobuf.DescriptorProto
              * @instance
              */
@@ -10003,7 +10003,7 @@ $root.google = (function() {
 
             /**
              * FieldDescriptorProto options.
-             * @member {(google.protobuf.IFieldOptions|null|undefined)}options
+             * @member {(google.protobuf.IFieldOptions|undefined)}options
              * @memberof google.protobuf.FieldDescriptorProto
              * @instance
              */
@@ -10492,7 +10492,7 @@ $root.google = (function() {
 
             /**
              * OneofDescriptorProto options.
-             * @member {(google.protobuf.IOneofOptions|null|undefined)}options
+             * @member {(google.protobuf.IOneofOptions|undefined)}options
              * @memberof google.protobuf.OneofDescriptorProto
              * @instance
              */
@@ -10716,7 +10716,7 @@ $root.google = (function() {
 
             /**
              * EnumDescriptorProto options.
-             * @member {(google.protobuf.IEnumOptions|null|undefined)}options
+             * @member {(google.protobuf.IEnumOptions|undefined)}options
              * @memberof google.protobuf.EnumDescriptorProto
              * @instance
              */
@@ -10973,7 +10973,7 @@ $root.google = (function() {
 
             /**
              * EnumValueDescriptorProto options.
-             * @member {(google.protobuf.IEnumValueOptions|null|undefined)}options
+             * @member {(google.protobuf.IEnumValueOptions|undefined)}options
              * @memberof google.protobuf.EnumValueDescriptorProto
              * @instance
              */
@@ -11210,7 +11210,7 @@ $root.google = (function() {
 
             /**
              * ServiceDescriptorProto options.
-             * @member {(google.protobuf.IServiceOptions|null|undefined)}options
+             * @member {(google.protobuf.IServiceOptions|undefined)}options
              * @memberof google.protobuf.ServiceDescriptorProto
              * @instance
              */
@@ -11478,7 +11478,7 @@ $root.google = (function() {
 
             /**
              * MethodDescriptorProto options.
-             * @member {(google.protobuf.IMethodOptions|null|undefined)}options
+             * @member {(google.protobuf.IMethodOptions|undefined)}options
              * @memberof google.protobuf.MethodDescriptorProto
              * @instance
              */


### PR DESCRIPTION
Messages with optional fields will now implement their corresponding
interfaces (IMessage)

fixes #834
fixes #837

as requested in #844